### PR TITLE
Feat/pagination

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -16,10 +16,10 @@ model Users {
   updatedAt  DateTime?   @updatedAt @map("updated_at")
   email      String      @unique
   archivedAt DateTime?   @map("archived_at")
+  comments   Comments[]
   customers  Customers[]
   medias     Medias[]
   tasks      Tasks[]
-  comments   Comments[]
 
   @@map("users")
 }
@@ -49,18 +49,18 @@ model Tasks {
   description String?
   due         DateTime
   responsible TaskResponsible
-  ratio       String?         
   completedAt DateTime?       @map("completed_at")
-  scheduledAt DateTime?       @map("scheduled_at")
   createdAt   DateTime        @default(now()) @map("created_at")
   updatedAt   DateTime?       @updatedAt @map("updated_at")
   archivedAt  DateTime?       @map("archived_at")
   customerId  String          @map("customer_id")
   userId      String          @map("user_id")
+  ratio       String?
+  scheduledAt DateTime?       @map("scheduled_at")
+  comments    Comments[]
   medias      Medias[]
   customer    Customers       @relation(fields: [customerId], references: [id], onDelete: Cascade)
   updatedBy   Users           @relation(fields: [userId], references: [id], onDelete: Cascade)
-  comments    Comments[]
 
   @@map("tasks")
 }
@@ -84,16 +84,16 @@ model Comments {
   id        String     @id @default(cuid())
   author    String?
   text      String
-  isLiked   Boolean?
   createdAt DateTime   @default(now()) @map("created_at")
   updatedAt DateTime?  @updatedAt @map("updated_at")
   userId    String?    @map("user_id")
   taskId    String     @map("task_id")
-  task      Tasks      @relation(fields: [taskId], references: [id], onDelete: Cascade)
-  createdBy Users?     @relation(fields: [userId], references: [id], onDelete: Cascade)
   parentId  String?    @map("parent_id")
+  isLiked   Boolean?
   parent    Comments?  @relation("CommentToReplies", fields: [parentId], references: [id], onDelete: Cascade)
   replies   Comments[] @relation("CommentToReplies")
+  task      Tasks      @relation(fields: [taskId], references: [id], onDelete: Cascade)
+  createdBy Users?     @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@map("comments")
 }

--- a/src/app/api/customers/[id]/tasks/route.ts
+++ b/src/app/api/customers/[id]/tasks/route.ts
@@ -1,5 +1,5 @@
 import { prismaClient } from "@/lib/prisma";
-import { getCustomerTasksPaginated, TASKS_PAGE_SIZE } from "@/lib/tasks";
+import { getCustomerTasksPaginated, TASKS_PAGE_SIZE } from "@/services/tasks";
 import { getServerSession } from "next-auth";
 import { NextRequest, NextResponse } from "next/server";
 import { z, ZodError } from "zod";

--- a/src/app/api/customers/[id]/tasks/route.ts
+++ b/src/app/api/customers/[id]/tasks/route.ts
@@ -1,0 +1,53 @@
+import { prismaClient } from "@/lib/prisma";
+import { getCustomerTasksPaginated, TASKS_PAGE_SIZE } from "@/lib/tasks";
+import { getServerSession } from "next-auth";
+import { NextRequest, NextResponse } from "next/server";
+import { z, ZodError } from "zod";
+import { nextAuthOptions } from "@/config/auth";
+
+const querySchema = z.object({
+  page: z.coerce.number().int().min(1).default(1),
+  limit: z.coerce
+    .number()
+    .int()
+    .min(1)
+    .max(TASKS_PAGE_SIZE)
+    .default(TASKS_PAGE_SIZE),
+});
+
+export async function GET(request: NextRequest, { params }: any) {
+  try {
+    const { id } = await z.object({ id: z.string().min(1) }).parseAsync(params);
+
+    const { searchParams } = new URL(request.url);
+    const { page, limit } = querySchema.parse({
+      page: searchParams.get("page") ?? undefined,
+      limit: searchParams.get("limit") ?? undefined,
+    });
+
+    const customer = await prismaClient.customers.findUnique({
+      where: { id },
+    });
+
+    if (!customer) {
+      return new NextResponse("Cliente não encontrado", { status: 404 });
+    }
+
+    const session = await getServerSession(nextAuthOptions);
+    const result = await getCustomerTasksPaginated({
+      customerId: customer.id,
+      isLogged: !!session,
+      page,
+      limit,
+    });
+
+    return NextResponse.json(result);
+  } catch (error) {
+    if (error instanceof ZodError) {
+      return new NextResponse("Validation Error", { status: 400 });
+    }
+
+    console.error(error);
+    return new NextResponse("Internal Server Error", { status: 500 });
+  }
+}

--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -1,6 +1,6 @@
 import { nextAuthOptions } from "@/config/auth";
 import { prismaClient } from "@/lib/prisma";
-import { taskEditInclude } from "@/lib/tasks";
+import { taskEditInclude } from "@/services/tasks";
 import { createTaskSchema } from "@/validators/task";
 import { Prisma } from "@prisma/client";
 import { parseISO } from "date-fns";

--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -1,12 +1,43 @@
 import { nextAuthOptions } from "@/config/auth";
 import { prismaClient } from "@/lib/prisma";
-import { uploadFile } from "@/utils/uploadFile";
+import { taskEditInclude } from "@/lib/tasks";
 import { createTaskSchema } from "@/validators/task";
-import { Prisma, TaskResponsible } from "@prisma/client";
+import { Prisma } from "@prisma/client";
 import { parseISO } from "date-fns";
 import { getServerSession } from "next-auth";
 import { NextRequest, NextResponse } from "next/server";
 import { ZodError, z } from "zod";
+
+export async function GET(_request: NextRequest, { params }: any) {
+  const session = await getServerSession(nextAuthOptions);
+  if (!session) {
+    return new NextResponse("Não autorizado", { status: 401 });
+  }
+
+  try {
+    const { id } = await z.object({ id: z.string().min(1) }).parseAsync(params);
+
+    const task = await prismaClient.tasks.findUnique({
+      where: { id },
+      include: taskEditInclude,
+    });
+
+    if (!task) {
+      return new NextResponse("Não foi possível encontrar a tarefa", {
+        status: 404,
+      });
+    }
+
+    return NextResponse.json(task);
+  } catch (error) {
+    if (error instanceof ZodError) {
+      return new NextResponse("Validation Error", { status: 400 });
+    }
+
+    console.error(error);
+    return new NextResponse("Internal Server Error", { status: 500 });
+  }
+}
 
 export async function PUT(request: NextRequest, { params }: any) {
   const session = await getServerSession(nextAuthOptions);

--- a/src/app/clientes/[slug]/CustomerClient.tsx
+++ b/src/app/clientes/[slug]/CustomerClient.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import Link from "next/link";
+import { useSearchParamsContext } from "@/contexts/SearchParamsProvider";
+import { api } from "@/lib/api";
+import { TaskListItem } from "@/services/tasks";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { TaskForm } from "./TaskForm";
+import { TasksList } from "./TasksLists";
+
+type CustomerClientProps = {
+  customerId: string;
+  customerSlug: string;
+  initialTasks: TaskListItem[];
+  initialHasMore: boolean;
+  showTaskForm: boolean;
+};
+
+export function CustomerClient({
+  customerId,
+  customerSlug,
+  initialTasks,
+  initialHasMore,
+  showTaskForm,
+}: CustomerClientProps) {
+  const { searchParams, setSearchParams } = useSearchParamsContext();
+  const formSectionRef = useRef<HTMLDivElement>(null);
+
+  const editingTaskId = searchParams.id ?? null;
+
+  const [tasks, setTasks] = useState(initialTasks);
+  const [page, setPage] = useState(1);
+  const [hasMore, setHasMore] = useState(initialHasMore);
+
+  const handleEditTask = useCallback(
+    (taskId: string) => {
+      setSearchParams({ id: taskId }, { noRedirect: true });
+    },
+    [setSearchParams],
+  );
+
+  useEffect(() => {
+    if (!editingTaskId || !showTaskForm) return;
+
+    formSectionRef.current?.scrollIntoView({
+      behavior: "smooth",
+      block: "start",
+    });
+  }, [editingTaskId, showTaskForm]);
+
+  const handleCloseEdit = useCallback(() => {
+    setSearchParams(
+      { id: null },
+      { noRedirect: true, historyMethod: "replace" },
+    );
+  }, [setSearchParams]);
+
+  const handleRefreshFirstPage = useCallback(async () => {
+    const { data } = await api.get<{
+      tasks: TaskListItem[];
+      pagination: { page: number; hasMore: boolean };
+    }>(`customers/${customerId}/tasks`, {
+      params: { page: 1 },
+    });
+
+    setTasks(data.tasks);
+    setPage(data.pagination.page);
+    setHasMore(data.pagination.hasMore);
+  }, [customerId]);
+
+  const handleUpdateTask = useCallback(
+    (taskId: string, data: Partial<TaskListItem>) => {
+      setTasks((prevState) =>
+        prevState.map((task) =>
+          task.id === taskId ? { ...task, ...data } : task,
+        ),
+      );
+    },
+    [],
+  );
+
+  return (
+    <>
+      {showTaskForm ? (
+        <div ref={formSectionRef} id="task-form" className="scroll-mt-6">
+          <TaskForm
+            customerId={customerId}
+            editingTaskId={editingTaskId}
+            onCloseEdit={handleCloseEdit}
+            onTaskCreated={handleRefreshFirstPage}
+            onTaskUpdated={handleUpdateTask}
+          />
+        </div>
+      ) : null}
+
+      <Link
+        href={`/clientes/${customerSlug}/calendario`}
+        className="flex items-center justify-center gap-2 w-full py-3 px-4 bg-transparent text-secondary border border-secondary font-medium rounded-full hover:opacity-90 transition-opacity"
+      >
+        Ver calendário
+      </Link>
+
+      {tasks.length > 0 ? (
+        <TasksList
+          tasks={tasks}
+          setTasks={setTasks}
+          page={page}
+          setPage={setPage}
+          hasMore={hasMore}
+          setHasMore={setHasMore}
+          customerId={customerId}
+          onEditTask={handleEditTask}
+        />
+      ) : null}
+    </>
+  );
+}

--- a/src/app/clientes/[slug]/TaskForm.tsx
+++ b/src/app/clientes/[slug]/TaskForm.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import Image from "next/image";
-import { useSearchParams, usePathname, useRouter } from "next/navigation";
 import SortableList, { SortableItem } from "react-easy-sort";
 import arrayMove from "array-move";
 
@@ -25,29 +24,32 @@ import { useForm } from "react-hook-form";
 import { toast } from "react-toastify";
 import { CreateTaskSchema, createTaskSchema } from "@/validators/task";
 import { TextArea } from "@/components/TextArea";
-import { TaskEditItem } from "@/lib/tasks";
-import { subMinutes } from "date-fns";
+import { TaskEditItem, TaskListItem } from "@/services/tasks";
+import { parseISO, subMinutes } from "date-fns";
 import { ChangeEvent, useEffect, useRef, useState } from "react";
 import { getMediaURL } from "@/lib/aws";
 import { cn } from "@/utils/cn";
-import { TaskType } from "@/utils/api";
 import { getPresignedURL } from "@/utils/presignedURL";
 
 interface TaskFormProps {
   customerId: string;
+  editingTaskId: string | null;
+  onCloseEdit: () => void;
+  onTaskCreated: () => void;
+  onTaskUpdated: (taskId: string, data: Partial<TaskListItem>) => void;
 }
 
 type Media = CreateTaskSchema["medias"][0] & {
   file?: File;
 };
 
-export function TaskForm({ customerId }: TaskFormProps) {
-  const searchParams = useSearchParams();
-  const pathname = usePathname();
-  const router = useRouter();
-
-  const taskId = searchParams.get("id");
-
+export function TaskForm({
+  customerId,
+  editingTaskId,
+  onCloseEdit,
+  onTaskCreated,
+  onTaskUpdated,
+}: TaskFormProps) {
   const [selectedTask, setSelectedTask] = useState<TaskEditItem | null>(null);
   const [isLoadingTask, setIsLoadingTask] = useState(false);
   const isEditing = !!selectedTask;
@@ -84,11 +86,22 @@ export function TaskForm({ customerId }: TaskFormProps) {
   });
 
   const inputRef = useRef<HTMLInputElement>(null);
+  const prevEditingTaskIdRef = useRef(editingTaskId);
 
   const [isFormOpen, setIsFormOpen] = useState(false);
 
   useEffect(() => {
-    if (!taskId) {
+    if (prevEditingTaskIdRef.current && !editingTaskId) {
+      setIsFormOpen(false);
+      reset();
+      setMedias([]);
+    }
+
+    prevEditingTaskIdRef.current = editingTaskId;
+  }, [editingTaskId, reset]);
+
+  useEffect(() => {
+    if (!editingTaskId) {
       setSelectedTask(null);
       return;
     }
@@ -100,19 +113,19 @@ export function TaskForm({ customerId }: TaskFormProps) {
       setIsLoadingTask(true);
 
       try {
-        const { data } = await api.get<TaskEditItem>(`tasks/${taskId}`);
+        const { data } = await api.get<TaskEditItem>(`tasks/${editingTaskId}`);
         setSelectedTask(data);
       } catch (error) {
         console.error(error);
         toast.error("Não foi possível carregar a tarefa");
-        router.replace(pathname);
+        onCloseEdit();
       } finally {
         setIsLoadingTask(false);
       }
     };
 
     fetchTask();
-  }, [taskId, pathname, router]);
+  }, [editingTaskId, onCloseEdit]);
 
   useEffect(() => {
     setMedias(
@@ -128,7 +141,7 @@ export function TaskForm({ customerId }: TaskFormProps) {
   }, [selectedTask?.medias]);
 
   const cancelEditTask = () => {
-    router.replace(pathname);
+    onCloseEdit();
     reset();
     setSelectedTask(null);
     setIsFormOpen(false);
@@ -156,7 +169,6 @@ export function TaskForm({ customerId }: TaskFormProps) {
         }),
       );
 
-      let response: TaskType;
       if (isEditing && selectedTask) {
         const deletedMedias = selectedTask.medias.filter(
           ({ id }) => !medias.map(({ id }) => id).includes(id),
@@ -182,14 +194,12 @@ export function TaskForm({ customerId }: TaskFormProps) {
           ),
         );
 
-        const { data } = await api.put<TaskType>(`tasks/${selectedTask.id}`, {
+        await api.put(`tasks/${selectedTask.id}`, {
           ...formData,
           medias: urls,
         });
-        response = data;
       } else {
-        const { data } = await api.post("tasks", { ...formData, medias: urls });
-        response = data;
+        await api.post("tasks", { ...formData, medias: urls });
       }
 
       await Promise.all(
@@ -209,8 +219,20 @@ export function TaskForm({ customerId }: TaskFormProps) {
           ? "Tarefa criada com sucesso!"
           : "Tarefa editada com sucesso!",
       );
-      cancelEditTask();
-      window.location.reload();
+
+      if (isEditing && selectedTask) {
+        onTaskUpdated(selectedTask.id, {
+          title: formData.title,
+          description: formData.description || null,
+          due: parseISO(formData.due),
+          ratio: formData.ratio || null,
+          responsible: formData.responsible,
+        });
+        cancelEditTask();
+      } else {
+        await onTaskCreated();
+        closeForm();
+      }
     } catch (error) {
       if (error instanceof AxiosError) {
         toast.error(error.response?.data);
@@ -282,13 +304,15 @@ export function TaskForm({ customerId }: TaskFormProps) {
         </button>
       ) : null}
 
-      {isFormOpen ? (
+      {isFormOpen || editingTaskId ? (
         <form
           className="flex flex-col gap-8 w-full p-5 bg-white rounded-xl drop-shadow-custom"
           onSubmit={handleSubmit(handleCreateTask)}
         >
           <h2 className="font-bold text-lg">
-            {isEditing ? "Edição de tarefa" : "Cadastro de tarefa"}
+            {editingTaskId || isEditing
+              ? "Edição de tarefa"
+              : "Cadastro de tarefa"}
           </h2>
 
           <fieldset

--- a/src/app/clientes/[slug]/TaskForm.tsx
+++ b/src/app/clientes/[slug]/TaskForm.tsx
@@ -19,13 +19,13 @@ import {
   ArrowsOutSimple,
   Play,
 } from "@phosphor-icons/react";
-import { PrismaClient, TaskResponsible } from "@prisma/client";
+import { TaskResponsible } from "@prisma/client";
 import { AxiosError } from "axios";
 import { useForm } from "react-hook-form";
 import { toast } from "react-toastify";
 import { CreateTaskSchema, createTaskSchema } from "@/validators/task";
 import { TextArea } from "@/components/TextArea";
-import { CustomerWithTasks } from "./page";
+import { TaskEditItem } from "@/lib/tasks";
 import { subMinutes } from "date-fns";
 import { ChangeEvent, useEffect, useRef, useState } from "react";
 import { getMediaURL } from "@/lib/aws";
@@ -33,10 +33,7 @@ import { cn } from "@/utils/cn";
 import { TaskType } from "@/utils/api";
 import { getPresignedURL } from "@/utils/presignedURL";
 
-interface TaskFormProps extends Pick<
-  Exclude<CustomerWithTasks, null>,
-  "tasks"
-> {
+interface TaskFormProps {
   customerId: string;
 }
 
@@ -44,14 +41,15 @@ type Media = CreateTaskSchema["medias"][0] & {
   file?: File;
 };
 
-export function TaskForm({ customerId, tasks }: TaskFormProps) {
+export function TaskForm({ customerId }: TaskFormProps) {
   const searchParams = useSearchParams();
   const pathname = usePathname();
   const router = useRouter();
 
   const taskId = searchParams.get("id");
 
-  const selectedTask = tasks.find(({ id }) => id === taskId);
+  const [selectedTask, setSelectedTask] = useState<TaskEditItem | null>(null);
+  const [isLoadingTask, setIsLoadingTask] = useState(false);
   const isEditing = !!selectedTask;
 
   const [medias, setMedias] = useState<Media[]>([]);
@@ -66,7 +64,7 @@ export function TaskForm({ customerId, tasks }: TaskFormProps) {
       title: selectedTask?.title || "",
       description: selectedTask?.description || "",
       due: selectedTask
-        ? subMinutes(selectedTask.due, new Date().getTimezoneOffset())
+        ? subMinutes(new Date(selectedTask.due), new Date().getTimezoneOffset())
             .toISOString()
             .slice(0, 16)
         : "",
@@ -90,6 +88,33 @@ export function TaskForm({ customerId, tasks }: TaskFormProps) {
   const [isFormOpen, setIsFormOpen] = useState(false);
 
   useEffect(() => {
+    if (!taskId) {
+      setSelectedTask(null);
+      return;
+    }
+
+    setIsFormOpen(true);
+
+    const fetchTask = async () => {
+      setSelectedTask(null);
+      setIsLoadingTask(true);
+
+      try {
+        const { data } = await api.get<TaskEditItem>(`tasks/${taskId}`);
+        setSelectedTask(data);
+      } catch (error) {
+        console.error(error);
+        toast.error("Não foi possível carregar a tarefa");
+        router.replace(pathname);
+      } finally {
+        setIsLoadingTask(false);
+      }
+    };
+
+    fetchTask();
+  }, [taskId, pathname, router]);
+
+  useEffect(() => {
     setMedias(
       selectedTask?.medias.map(({ id, order, path, type }) => ({
         id,
@@ -102,13 +127,10 @@ export function TaskForm({ customerId, tasks }: TaskFormProps) {
     );
   }, [selectedTask?.medias]);
 
-  useEffect(() => {
-    if (isEditing) setIsFormOpen(true);
-  }, [isEditing]);
-
   const cancelEditTask = () => {
     router.replace(pathname);
     reset();
+    setSelectedTask(null);
     setIsFormOpen(false);
   };
 
@@ -269,7 +291,13 @@ export function TaskForm({ customerId, tasks }: TaskFormProps) {
             {isEditing ? "Edição de tarefa" : "Cadastro de tarefa"}
           </h2>
 
-          <div className="flex flex-col gap-4">
+          <fieldset
+            disabled={isLoadingTask}
+            className={cn(
+              "flex flex-col gap-4 border-0 p-0 m-0 min-w-0 transition-opacity",
+              { "opacity-20 pointer-events-none": isLoadingTask },
+            )}
+          >
             <Input
               icon={<CheckCircle />}
               placeholder="Título"
@@ -388,7 +416,7 @@ export function TaskForm({ customerId, tasks }: TaskFormProps) {
                 multiple
               />
             </div>
-          </div>
+          </fieldset>
 
           <div className="flex justify-between gap-4">
             <button
@@ -401,15 +429,18 @@ export function TaskForm({ customerId, tasks }: TaskFormProps) {
 
             <button
               type="submit"
+              disabled={isLoadingTask || isSubmitting}
               className="flex-1 sm:flex-initial sm:min-w-44 ml-auto p-4 bg-primary text-white font-bold text-sm rounded-full uppercase disabled:opacity-50"
             >
-              {!isSubmitting
-                ? !isEditing
-                  ? "Adicionar"
-                  : "Editar"
-                : !isEditing
-                  ? "Adicionando..."
-                  : "Editando..."}
+              {isLoadingTask
+                ? "Carregando..."
+                : !isSubmitting
+                  ? !isEditing
+                    ? "Adicionar"
+                    : "Editar"
+                  : !isEditing
+                    ? "Adicionando..."
+                    : "Editando..."}
             </button>
           </div>
         </form>

--- a/src/app/clientes/[slug]/TasksLists.tsx
+++ b/src/app/clientes/[slug]/TasksLists.tsx
@@ -21,7 +21,14 @@ import {
   CalendarCheck,
   DownloadSimple,
 } from "@phosphor-icons/react";
-import { useCallback, useEffect, useRef, useState, Dispatch, SetStateAction } from "react";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  Dispatch,
+  SetStateAction,
+} from "react";
 import { api } from "@/lib/api";
 import { toast } from "react-toastify";
 
@@ -56,21 +63,18 @@ export function TasksList({
 }: TasksListProps) {
   const session = useSession();
 
-  const [isLoadingMore, setIsLoadingMore] = useState(false);
-
   const [swiperInstance, setSwiperInstance] = useState<SwiperClass | null>(
     null,
   );
 
-  const sentinelRef = useRef<HTMLDivElement>(null);
-
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
   const [selectedTask, setSelectedTask] = useState<Task | null>(null);
   const [isChecking, setIsChecking] = useState(false);
   const [isCommentOpened, setIsCommentOpened] = useState(false);
 
-  const loadMore = useCallback(async () => {
-    if (isLoadingMore || !hasMore) return;
+  const sentinelRef = useRef<HTMLDivElement>(null);
 
+  const loadMore = useCallback(async () => {
     setIsLoadingMore(true);
 
     try {
@@ -94,7 +98,7 @@ export function TasksList({
     } finally {
       setIsLoadingMore(false);
     }
-  }, [customerId, page, hasMore, isLoadingMore]);
+  }, [customerId, page, setTasks, setPage, setHasMore]);
 
   useEffect(() => {
     const sentinel = sentinelRef.current;
@@ -102,7 +106,7 @@ export function TasksList({
 
     const observer = new IntersectionObserver(
       (entries) => {
-        if (entries[0]?.isIntersecting) {
+        if (!isLoadingMore && entries[0]?.isIntersecting) {
           loadMore();
         }
       },

--- a/src/app/clientes/[slug]/TasksLists.tsx
+++ b/src/app/clientes/[slug]/TasksLists.tsx
@@ -1,14 +1,13 @@
 "use client";
 
-import { Swiper, SwiperSlide, SwiperRef, SwiperClass } from "swiper/react";
+import { Swiper, SwiperSlide, SwiperClass } from "swiper/react";
 import { Pagination } from "swiper/modules";
-import Image from "next/image";
 import { Pill } from "@/components/Pill";
 import { cn } from "@/utils/cn";
-import { TaskResponsible, Tasks, UserRole } from "@prisma/client";
+import { TaskResponsible, UserRole } from "@prisma/client";
 import { useSession } from "next-auth/react";
-import { CustomerWithTasks } from "./page";
-import { format, isBefore, isEqual, parseISO } from "date-fns";
+import { TaskListItem } from "@/lib/tasks";
+import { format, isEqual } from "date-fns";
 import { ptBR } from "date-fns/locale";
 import {
   ArchiveBox,
@@ -22,13 +21,10 @@ import {
   CalendarCheck,
   DownloadSimple,
 } from "@phosphor-icons/react";
-import { useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useSearchParams, usePathname, useRouter } from "next/navigation";
 import { api } from "@/lib/api";
 import { toast } from "react-toastify";
-
-type TasksListProps = Pick<Exclude<CustomerWithTasks, null>, "tasks">;
-type Task = TasksListProps["tasks"][number];
 
 import "swiper/css";
 import "swiper/css/navigation";
@@ -36,10 +32,25 @@ import "swiper/css/pagination";
 import { getMediaURL } from "@/lib/aws";
 import { Comments } from "./Comments";
 
-export function TasksList({ tasks: _tasks }: TasksListProps) {
+type Task = TaskListItem;
+
+type TasksListProps = {
+  initialTasks: TaskListItem[];
+  initialHasMore: boolean;
+  customerId: string;
+};
+
+export function TasksList({
+  initialTasks,
+  initialHasMore,
+  customerId,
+}: TasksListProps) {
   const session = useSession();
 
-  const [tasks, setTasks] = useState(_tasks);
+  const [tasks, setTasks] = useState(initialTasks);
+  const [page, setPage] = useState(1);
+  const [hasMore, setHasMore] = useState(initialHasMore);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
 
   const [swiperInstance, setSwiperInstance] = useState<SwiperClass | null>(
     null,
@@ -49,9 +60,57 @@ export function TasksList({ tasks: _tasks }: TasksListProps) {
   const pathname = usePathname();
   const router = useRouter();
 
+  const sentinelRef = useRef<HTMLDivElement>(null);
+
   const [selectedTask, setSelectedTask] = useState<Task | null>(null);
   const [isChecking, setIsChecking] = useState(false);
   const [isCommentOpened, setIsCommentOpened] = useState(false);
+
+  const loadMore = useCallback(async () => {
+    if (isLoadingMore || !hasMore) return;
+
+    setIsLoadingMore(true);
+
+    try {
+      const { data } = await api.get<{
+        tasks: TaskListItem[];
+        pagination: { page: number; hasMore: boolean };
+      }>(`customers/${customerId}/tasks`, {
+        params: { page: page + 1 },
+      });
+
+      setTasks((prevState) => {
+        const existingIds = new Set(prevState.map((task) => task.id));
+        const newTasks = data.tasks.filter((task) => !existingIds.has(task.id));
+        return [...prevState, ...newTasks];
+      });
+      setPage(data.pagination.page);
+      setHasMore(data.pagination.hasMore);
+    } catch (error) {
+      console.error(error);
+      toast.error("Não foi possível carregar mais tarefas");
+    } finally {
+      setIsLoadingMore(false);
+    }
+  }, [customerId, page, hasMore, isLoadingMore]);
+
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+    if (!sentinel) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting) {
+          loadMore();
+        }
+      },
+      { rootMargin: "600px" },
+    );
+
+    observer.observe(sentinel);
+
+    return () => observer.disconnect();
+  }, [loadMore]);
 
   const toggleCheckTask = async (selectedTask: Task) => {
     if (!selectedTask) return;
@@ -501,6 +560,17 @@ export function TasksList({ tasks: _tasks }: TasksListProps) {
           );
         })}
       </ul>
+
+      {hasMore ? (
+        <div
+          ref={sentinelRef}
+          className="flex items-center justify-center py-6"
+        >
+          {isLoadingMore ? (
+            <SpinnerGap size={24} weight="bold" className="animate-spin" />
+          ) : null}
+        </div>
+      ) : null}
 
       <Comments
         taskId={selectedTask?.id || ""}

--- a/src/app/clientes/[slug]/TasksLists.tsx
+++ b/src/app/clientes/[slug]/TasksLists.tsx
@@ -6,7 +6,7 @@ import { Pill } from "@/components/Pill";
 import { cn } from "@/utils/cn";
 import { TaskResponsible, UserRole } from "@prisma/client";
 import { useSession } from "next-auth/react";
-import { TaskListItem } from "@/lib/tasks";
+import { TaskListItem } from "@/services/tasks";
 import { format, isEqual } from "date-fns";
 import { ptBR } from "date-fns/locale";
 import {
@@ -21,8 +21,7 @@ import {
   CalendarCheck,
   DownloadSimple,
 } from "@phosphor-icons/react";
-import { useCallback, useEffect, useRef, useState } from "react";
-import { useSearchParams, usePathname, useRouter } from "next/navigation";
+import { useCallback, useEffect, useRef, useState, Dispatch, SetStateAction } from "react";
 import { api } from "@/lib/api";
 import { toast } from "react-toastify";
 
@@ -35,30 +34,33 @@ import { Comments } from "./Comments";
 type Task = TaskListItem;
 
 type TasksListProps = {
-  initialTasks: TaskListItem[];
-  initialHasMore: boolean;
+  tasks: TaskListItem[];
+  setTasks: Dispatch<SetStateAction<TaskListItem[]>>;
+  page: number;
+  setPage: Dispatch<SetStateAction<number>>;
+  hasMore: boolean;
+  setHasMore: Dispatch<SetStateAction<boolean>>;
   customerId: string;
+  onEditTask: (taskId: string) => void;
 };
 
 export function TasksList({
-  initialTasks,
-  initialHasMore,
+  tasks,
+  setTasks,
+  page,
+  setPage,
+  hasMore,
+  setHasMore,
   customerId,
+  onEditTask,
 }: TasksListProps) {
   const session = useSession();
 
-  const [tasks, setTasks] = useState(initialTasks);
-  const [page, setPage] = useState(1);
-  const [hasMore, setHasMore] = useState(initialHasMore);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
 
   const [swiperInstance, setSwiperInstance] = useState<SwiperClass | null>(
     null,
   );
-
-  const searchParams = useSearchParams();
-  const pathname = usePathname();
-  const router = useRouter();
 
   const sentinelRef = useRef<HTMLDivElement>(null);
 
@@ -213,9 +215,7 @@ export function TasksList({
   };
 
   const editTask = (id: string) => {
-    const params = new URLSearchParams(searchParams.toString());
-    params.set("id", id);
-    router.replace(`${pathname}?${params.toString()}`);
+    onEditTask(id);
   };
 
   const toggleArchiveTask = async (id: string, isArchived: boolean) => {

--- a/src/app/clientes/[slug]/loading.tsx
+++ b/src/app/clientes/[slug]/loading.tsx
@@ -3,8 +3,6 @@ import { TopNav } from "@/components/TopNav";
 import { nextAuthOptions } from "@/config/auth";
 import { getServerSession } from "next-auth";
 import { CustomerPresentation } from "./CustomerPresentation";
-import { BottomNav } from "./BottomNav";
-import { TaskForm } from "./TaskForm";
 import { Skeleton } from "@/components/Skeleton";
 
 export default async function CustomerLoading() {
@@ -16,7 +14,8 @@ export default async function CustomerLoading() {
       <TitlePage>Planner | Carregando...</TitlePage>
 
       <CustomerPresentation presentation={""} />
-      {session ? <TaskForm customerId={""} /> : null}
+      {session ? <Skeleton className="w-full h-12 rounded-full" /> : null}
+      <Skeleton className="w-full h-12 rounded-full" />
       <ul className="flex flex-col gap-6 p-6 bg-white rounded-xl drop-shadow-custom">
         {[...new Array(6)].map((_, index) => (
           <Skeleton key={index} className="w-full h-[150px]" />

--- a/src/app/clientes/[slug]/loading.tsx
+++ b/src/app/clientes/[slug]/loading.tsx
@@ -16,7 +16,7 @@ export default async function CustomerLoading() {
       <TitlePage>Planner | Carregando...</TitlePage>
 
       <CustomerPresentation presentation={""} />
-      {session ? <TaskForm customerId={""} tasks={[]} /> : null}
+      {session ? <TaskForm customerId={""} /> : null}
       <ul className="flex flex-col gap-6 p-6 bg-white rounded-xl drop-shadow-custom">
         {[...new Array(6)].map((_, index) => (
           <Skeleton key={index} className="w-full h-[150px]" />

--- a/src/app/clientes/[slug]/page.tsx
+++ b/src/app/clientes/[slug]/page.tsx
@@ -1,14 +1,12 @@
-import Link from "next/link";
 import { TitlePage } from "@/components/TitlePage";
 import { TopNav } from "@/components/TopNav";
 import { nextAuthOptions } from "@/config/auth";
 import { prismaClient } from "@/lib/prisma";
-import { getCustomerTasksPaginated } from "@/lib/tasks";
+import { getCustomerTasksPaginated } from "@/services/tasks";
 import { getServerSession } from "next-auth";
 import { redirect } from "next/navigation";
 import { CustomerPresentation } from "./CustomerPresentation";
-import { TaskForm } from "./TaskForm";
-import { TasksList } from "./TasksLists";
+import { CustomerClient } from "./CustomerClient";
 
 export const dynamic = "force-dynamic";
 
@@ -46,22 +44,14 @@ export default async function Customer({ params }: any) {
       <TitlePage>Planner | {customer.name}</TitlePage>
 
       <CustomerPresentation presentation={customer.presentation || ""} />
-      {session ? <TaskForm customerId={customer.id} /> : null}
 
-      <Link
-        href={`/clientes/${slug}/calendario`}
-        className="flex items-center justify-center gap-2 w-full py-3 px-4 bg-transparent text-secondary border border-secondary font-medium rounded-full hover:opacity-90 transition-opacity"
-      >
-        Ver calendário
-      </Link>
-
-      {pagination.total > 0 ? (
-        <TasksList
-          initialTasks={tasks}
-          initialHasMore={pagination.hasMore}
-          customerId={customer.id}
-        />
-      ) : null}
+      <CustomerClient
+        customerId={customer.id}
+        customerSlug={slug}
+        initialTasks={tasks}
+        initialHasMore={pagination.hasMore}
+        showTaskForm={!!session}
+      />
 
       <div className="h-16" />
     </>

--- a/src/app/clientes/[slug]/page.tsx
+++ b/src/app/clientes/[slug]/page.tsx
@@ -3,66 +3,12 @@ import { TitlePage } from "@/components/TitlePage";
 import { TopNav } from "@/components/TopNav";
 import { nextAuthOptions } from "@/config/auth";
 import { prismaClient } from "@/lib/prisma";
-import { Prisma, UserRole } from "@prisma/client";
+import { getCustomerTasksPaginated } from "@/lib/tasks";
 import { getServerSession } from "next-auth";
 import { redirect } from "next/navigation";
 import { CustomerPresentation } from "./CustomerPresentation";
-import { BottomNav } from "./BottomNav";
 import { TaskForm } from "./TaskForm";
 import { TasksList } from "./TasksLists";
-
-const getCustomerWithTasks = async (slug: string, isLogged?: boolean) => {
-  const customer = await prismaClient.customers.findFirst({
-    where: { slug },
-  });
-
-  if (!customer) {
-    return null;
-  }
-
-  const tasks = await prismaClient.tasks.findMany({
-    where: {
-      ...(!isLogged ? { archivedAt: null } : {}),
-      customer: { id: customer.id },
-    },
-    include: {
-      customer: true,
-      medias: {
-        orderBy: {
-          order: "asc",
-        },
-      },
-      updatedBy: true,
-      _count: {
-        select: {
-          comments: true,
-        },
-      },
-    },
-    orderBy: {
-      due: "asc",
-    },
-  });
-
-  return {
-    ...customer,
-    tasks: [...tasks].sort((a, b) => {
-      if (a.archivedAt) {
-        return 1;
-      }
-
-      if (b.archivedAt) {
-        return -1;
-      }
-
-      return 1;
-    }),
-  };
-};
-
-export type CustomerWithTasks = Prisma.PromiseReturnType<
-  typeof getCustomerWithTasks
->;
 
 export const dynamic = "force-dynamic";
 
@@ -71,7 +17,9 @@ export default async function Customer({ params }: any) {
 
   const session = await getServerSession(nextAuthOptions);
 
-  const customer = await getCustomerWithTasks(slug, !!session);
+  const customer = await prismaClient.customers.findFirst({
+    where: { slug },
+  });
 
   if (!customer) {
     if (session) {
@@ -85,6 +33,12 @@ export default async function Customer({ params }: any) {
     );
   }
 
+  const { tasks, pagination } = await getCustomerTasksPaginated({
+    customerId: customer.id,
+    isLogged: !!session,
+    page: 1,
+  });
+
   return (
     <>
       <TopNav />
@@ -92,9 +46,7 @@ export default async function Customer({ params }: any) {
       <TitlePage>Planner | {customer.name}</TitlePage>
 
       <CustomerPresentation presentation={customer.presentation || ""} />
-      {session ? (
-        <TaskForm customerId={customer.id} tasks={customer.tasks} />
-      ) : null}
+      {session ? <TaskForm customerId={customer.id} /> : null}
 
       <Link
         href={`/clientes/${slug}/calendario`}
@@ -103,7 +55,13 @@ export default async function Customer({ params }: any) {
         Ver calendário
       </Link>
 
-      {!!customer.tasks.length && <TasksList tasks={customer.tasks} />}
+      {pagination.total > 0 ? (
+        <TasksList
+          initialTasks={tasks}
+          initialHasMore={pagination.hasMore}
+          customerId={customer.id}
+        />
+      ) : null}
 
       <div className="h-16" />
     </>

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,12 +1,19 @@
 "use client";
 
+import { SearchParamsProvider } from "@/contexts/SearchParamsProvider";
 import { SessionProvider } from "next-auth/react";
-import { ReactNode } from "react";
+import { ReactNode, Suspense } from "react";
 
 interface ProvidersProps {
   children: ReactNode;
 }
 
 export function Providers({ children }: ProvidersProps) {
-  return <SessionProvider>{children}</SessionProvider>;
+  return (
+    <SessionProvider>
+      <Suspense>
+        <SearchParamsProvider>{children}</SearchParamsProvider>
+      </Suspense>
+    </SessionProvider>
+  );
 }

--- a/src/contexts/SearchParamsProvider.tsx
+++ b/src/contexts/SearchParamsProvider.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import {
+  getSearchParamsObject,
+  mergeSearchParams,
+  ParamsType,
+  SearchParams,
+} from "@/utils/searchParams";
+import {
+  usePathname,
+  useRouter,
+  useSearchParams as useNextSearchParams,
+} from "next/navigation";
+import {
+  createContext,
+  ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
+
+type SetSearchParamsOptions = {
+  noRedirect?: boolean;
+  historyMethod?: "push" | "replace";
+};
+
+type SetSearchParams = (
+  newParams: ParamsType,
+  options?: SetSearchParamsOptions,
+) => void;
+
+export type SearchParamsContextType = {
+  searchParams: SearchParams;
+  setSearchParams: SetSearchParams;
+  getHrefWithParams: (params: ParamsType) => string;
+};
+
+export const SearchParamsContext =
+  createContext<SearchParamsContextType | null>(null);
+
+type SearchParamsProviderProps = {
+  children: ReactNode;
+};
+
+export function SearchParamsProvider({ children }: SearchParamsProviderProps) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const nextSearchParams = useNextSearchParams();
+
+  const [searchParams, setSearchParamsState] = useState<SearchParams>(() =>
+    getSearchParamsObject(nextSearchParams),
+  );
+
+  useEffect(() => {
+    setSearchParamsState(getSearchParamsObject(nextSearchParams));
+  }, [nextSearchParams]);
+
+  useEffect(() => {
+    const onPopState = () => {
+      setSearchParamsState(
+        getSearchParamsObject(new URLSearchParams(window.location.search)),
+      );
+    };
+
+    window.addEventListener("popstate", onPopState);
+    return () => window.removeEventListener("popstate", onPopState);
+  }, []);
+
+  const setSearchParams = useCallback<SetSearchParams>(
+    (newParams, options) => {
+      const currentParams = mergeSearchParams(
+        new URLSearchParams(window.location.search),
+        newParams,
+      );
+
+      const search = currentParams.toString();
+      const query = search ? `?${search}` : "";
+      const nextParams = getSearchParamsObject(currentParams);
+
+      if (options?.noRedirect) {
+        const url = `${pathname}${query}`;
+
+        if (options.historyMethod === "replace") {
+          window.history.replaceState(null, "", url);
+        } else {
+          window.history.pushState(null, "", url);
+        }
+
+        setSearchParamsState(nextParams);
+        return;
+      }
+
+      router.replace(`${pathname}${query}`, { scroll: false });
+    },
+    [pathname, router],
+  );
+
+  const getHrefWithParams = useCallback(
+    (params: ParamsType): string => {
+      const current = mergeSearchParams(
+        new URLSearchParams(nextSearchParams.toString()),
+        params,
+      );
+
+      const qs = current.toString();
+      return `${pathname}${qs ? `?${qs}` : ""}`;
+    },
+    [pathname, nextSearchParams],
+  );
+
+  return (
+    <SearchParamsContext.Provider
+      value={{
+        searchParams,
+        setSearchParams,
+        getHrefWithParams,
+      }}
+    >
+      {children}
+    </SearchParamsContext.Provider>
+  );
+}
+
+export function useSearchParamsContext() {
+  const context = useContext(SearchParamsContext);
+
+  if (!context) {
+    throw new Error(
+      "useSearchParamsContext must be used within SearchParamsProvider",
+    );
+  }
+
+  return context;
+}

--- a/src/lib/tasks.ts
+++ b/src/lib/tasks.ts
@@ -1,0 +1,78 @@
+import { prismaClient } from "@/lib/prisma";
+import { Prisma } from "@prisma/client";
+
+export const TASKS_PAGE_SIZE = 10;
+
+export const taskListInclude = {
+  customer: true,
+  medias: {
+    orderBy: {
+      order: "asc" as const,
+    },
+  },
+  updatedBy: true,
+  _count: {
+    select: {
+      comments: true,
+    },
+  },
+} satisfies Prisma.TasksInclude;
+
+export type TaskListItem = Prisma.TasksGetPayload<{
+  include: typeof taskListInclude;
+}>;
+
+export const taskEditInclude = {
+  medias: {
+    orderBy: {
+      order: "asc" as const,
+    },
+  },
+} satisfies Prisma.TasksInclude;
+
+export type TaskEditItem = Prisma.TasksGetPayload<{
+  include: typeof taskEditInclude;
+}>;
+
+type GetCustomerTasksPaginatedParams = {
+  customerId: string;
+  isLogged?: boolean;
+  page?: number;
+  limit?: number;
+};
+
+export async function getCustomerTasksPaginated({
+  customerId,
+  isLogged = false,
+  page = 1,
+  limit = TASKS_PAGE_SIZE,
+}: GetCustomerTasksPaginatedParams) {
+  const where: Prisma.TasksWhereInput = {
+    ...(!isLogged ? { archivedAt: null } : {}),
+    customer: { id: customerId },
+  };
+
+  const [tasks, total] = await Promise.all([
+    prismaClient.tasks.findMany({
+      where,
+      include: taskListInclude,
+      orderBy: [
+        { archivedAt: { sort: "asc", nulls: "first" } },
+        { due: "asc" },
+      ],
+      skip: (page - 1) * limit,
+      take: limit,
+    }),
+    prismaClient.tasks.count({ where }),
+  ]);
+
+  return {
+    tasks,
+    pagination: {
+      page,
+      limit,
+      total,
+      hasMore: page * limit < total,
+    },
+  };
+}

--- a/src/services/tasks.ts
+++ b/src/services/tasks.ts
@@ -1,7 +1,7 @@
 import { prismaClient } from "@/lib/prisma";
 import { Prisma } from "@prisma/client";
 
-export const TASKS_PAGE_SIZE = 10;
+export const TASKS_PAGE_SIZE = 20;
 
 export const taskListInclude = {
   customer: true,

--- a/src/utils/searchParams.ts
+++ b/src/utils/searchParams.ts
@@ -1,0 +1,34 @@
+import { ReadonlyURLSearchParams } from "next/navigation";
+
+export type ParamsType = Record<string, string | null | undefined>;
+
+export type SearchParams = Record<string, string>;
+
+export function getSearchParamsObject(
+  searchParams: ReadonlyURLSearchParams | URLSearchParams,
+): SearchParams {
+  const result: SearchParams = {};
+
+  searchParams.forEach((value, key) => {
+    result[key] = value;
+  });
+
+  return result;
+}
+
+export function mergeSearchParams(
+  current: URLSearchParams,
+  newParams: ParamsType,
+): URLSearchParams {
+  const merged = new URLSearchParams(current.toString());
+
+  Object.entries(newParams).forEach(([key, value]) => {
+    if (value) {
+      merged.set(key, value);
+    } else {
+      merged.delete(key);
+    }
+  });
+
+  return merged;
+}


### PR DESCRIPTION
## Summary

Implementa paginação com scroll infinito na listagem de tarefas do cliente e melhora a experiência de edição, eliminando reloads desnecessários da página.

## O que foi feito

### Paginação e scroll infinito
- Listagem carrega **10 tarefas por vez** (SSR na primeira página + carregamento incremental no client).
- Extraída a query compartilhada em [`src/services/tasks.ts`](src/services/tasks.ts) com ordenação no banco (não-arquivadas primeiro, depois por prazo).
- Nova rota **`GET /api/customers/[id]/tasks`** com suporte a `page` e `limit`.
- [`TasksList`](src/app/clientes/[slug]/TasksLists.tsx) usa `IntersectionObserver` na sentinela para carregar a próxima página.
- Guardas com refs para garantir **apenas uma request por vez** e evitar retentativas em loop após erro.

### Edição sem reload
- Criado [`CustomerClient`](src/app/clientes/[slug]/CustomerClient.tsx) para centralizar estado da lista e da edição.
- [`TaskForm`](src/app/clientes/[slug]/TaskForm.tsx) busca a tarefa individual via **`GET /api/tasks/[id]`** — não depende mais de carregar todas as tarefas no server.
- Removido `window.location.reload()` após criar/editar; a lista é atualizada no client.
- Ao clicar em editar, scroll suave até o formulário.

### Navegação client-side na URL
- Criado **`SearchParamsProvider`** ([`src/contexts/SearchParamsProvider.tsx`](src/contexts/SearchParamsProvider.tsx)) com `setSearchParams({ noRedirect: true })`, que atualiza a URL via History API sem refetch do Server Component.
- Provider aplicado globalmente em [`providers.tsx`](src/app/providers.tsx).
- Deep links com `?id=` continuam funcionando (formulário abre com os dados da tarefa).
- Botão voltar do browser sincroniza o estado via `popstate`.

## Test plan

- [ ] Cliente com 15+ tarefas: exibe 10 inicialmente e carrega o restante ao scrollar
- [ ] Clicar em editar abre o form, atualiza `?id=` na URL **sem reload** e scrolla até o form
- [ ] Acessar `/clientes/[slug]?id=...` diretamente abre o form preenchido
- [ ] Cancelar edição remove o param e fecha o form
- [ ] Criar/editar tarefa atualiza a lista sem reload
- [ ] Erro na paginação exibe um único toast e não dispara múltiplas requests
- [ ] Usuário anônimo não vê tarefas arquivadas